### PR TITLE
Allow to build without ROS in a ROS-enabled environment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0048 NEW)
+
+option(DISABLE_ROS OFF)
 project(mc_rtc_data VERSION 1.0.2)
 
 enable_testing()
+
+if(DISABLE_ROS)
+  message(STATUS "Building without ROS support as DISABLE_ROS=ON")
+endif()
 
 add_subdirectory(jvrc_description)
 add_subdirectory(mc_env_description)

--- a/jvrc_description/CMakeLists.txt
+++ b/jvrc_description/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0048 NEW)
 project(jvrc_description VERSION 1.0.2)
 
-find_package(catkin)
+find_package(catkin QUIET)
 
 if(${catkin_FOUND})
 

--- a/jvrc_description/CMakeLists.txt
+++ b/jvrc_description/CMakeLists.txt
@@ -4,7 +4,7 @@ project(jvrc_description VERSION 1.0.2)
 
 find_package(catkin QUIET)
 
-if(${catkin_FOUND})
+if(NOT DISABLE_ROS AND ${catkin_FOUND})
 
   catkin_package()
 

--- a/mc_env_description/CMakeLists.txt
+++ b/mc_env_description/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mc_env_description VERSION 1.0.2)
 
 find_package(catkin QUIET)
 
-if(${catkin_FOUND})
+if(NOT DISABLE_ROS AND ${catkin_FOUND})
 
   catkin_package()
 

--- a/mc_env_description/CMakeLists.txt
+++ b/mc_env_description/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0048 NEW)
 project(mc_env_description VERSION 1.0.2)
 
-find_package(catkin)
+find_package(catkin QUIET)
 
 if(${catkin_FOUND})
 

--- a/mc_int_obj_description/CMakeLists.txt
+++ b/mc_int_obj_description/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0048 NEW)
 project(mc_int_obj_description VERSION 1.0.2)
 
-find_package(catkin)
+find_package(catkin QUIET)
 
 if(${catkin_FOUND})
 

--- a/mc_int_obj_description/CMakeLists.txt
+++ b/mc_int_obj_description/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mc_int_obj_description VERSION 1.0.2)
 
 find_package(catkin QUIET)
 
-if(${catkin_FOUND})
+if(NOT DISABLE_ROS AND ${catkin_FOUND})
 
   catkin_package()
 


### PR DESCRIPTION
Explicitely set `DISABLE_ROS=ON` if you wish to build without ROS but have `catkin` installed on your system.